### PR TITLE
Add a note about how to test blade components.

### DIFF
--- a/src/testbench/basic/testcase.md
+++ b/src/testbench/basic/testcase.md
@@ -159,3 +159,20 @@ protected function resolveApplicationHttpKernel($app)
     $app->singleton('Illuminate\Contracts\Http\Kernel', 'Tests\Http\Kernel');
 }
 ```
+
+## Testing blade components
+
+You can easily test blade components with Laravel's `Illuminate\Foundation\Testing\Concerns\InteractsWithViews` trait.
+
+```php
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+
+class TestCase extends \Orchestra\Testbench\TestCase
+{
+    use InteractsWithViews;
+}
+```


### PR DESCRIPTION
This was something I tried to do myself by looking at Laravel's testing documentation and saw it had a `blade()` method in its `TestCase`. Trying to use that method in Orchestra will throw an error, and no documentation is found on how to test views and blade components in Orchestra, adding this note will hopefully save someone else the headache.

The wording might need some work, only include blade components but the trait includes ways to test views, blade files, blade components, and view errors.

See trait source file [InteractsWithViews.php](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Testing/Concerns/InteractsWithViews.php) for methods included.