### PR TITLE
chore(testbench): list Laravel v12 in Version Compatibility table

### DIFF
--- a/testbench.md
+++ b/testbench.md
@@ -36,6 +36,7 @@ vendor/bin/testbench workbench:install
  9.x      | 7.x
  10.x     | 8.x
  11.x     | 9.x
+ 12.x     | 10.x
 
 ## Configuration
 


### PR DESCRIPTION
Hi @crynobone,
I noticed that the version compatibility table for Testbench wasn't updated to list Laravel 12 as supported version by installing Testbench v10.